### PR TITLE
NXCM-4749 maven plugins should be java 5 source compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -348,8 +348,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.6</source>
-            <target>1.6</target>
+            <source>1.5</source>
+            <target>1.5</target>
           </configuration>
         </plugin>
         <!-- Manually run with: mvn clean com.mycila.maven-license-plugin:maven-license-plugin:1.9.0:format -->


### PR DESCRIPTION
Easy change, only a pull because I want confirmation java 6 was not intentional
