### PR TITLE
Staging release doesn't work well when there is a mirrorOf declaration.

### DIFF
--- a/nexus-staging-maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/deploy/strategy/AbstractStagingDeployStrategy.java
+++ b/nexus-staging-maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/deploy/strategy/AbstractStagingDeployStrategy.java
@@ -244,7 +244,8 @@ public abstract class AbstractStagingDeployStrategy
             else
             {
                 stagingProfile = stagingService.selectProfile( parameters.getStagingProfileId() );
-                getLogger().info( " * Using staging profile ID \"" + stagingProfile.getId() + "\" (configured by user)." );
+                getLogger().info(
+                    " * Using staging profile ID \"" + stagingProfile.getId() + "\" (configured by user)." );
             }
             return stagingProfile.getId();
         }
@@ -553,12 +554,12 @@ public abstract class AbstractStagingDeployStrategy
         }
     }
 
-    protected ArtifactRepository getArtifactRepositoryForNexus( final StagingRepository stagingRepository )
+    protected ArtifactRepository getDeploymentArtifactRepositoryForNexusStagingRepository( final StagingRepository stagingRepository )
         throws InvalidRepositoryException
     {
         final ArtifactRepository result =
-            artifactRepositoryFactory.createArtifactRepository( getRemoting().getServer().getId(),
-                stagingRepository.getUrl(), artifactRepositoryLayout, null, null );
+            artifactRepositoryFactory.createDeploymentArtifactRepository( getRemoting().getServer().getId(),
+                stagingRepository.getUrl(), artifactRepositoryLayout, true );
         return result;
     }
 }

--- a/nexus-staging-maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/deploy/strategy/StagingDeployStrategy.java
+++ b/nexus-staging-maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/deploy/strategy/StagingDeployStrategy.java
@@ -120,7 +120,7 @@ public class StagingDeployStrategy
                 getLogger().info( " * Uploading locally staged artifacts to profile " + stagingProfile.getName() );
                 deployUp( request.getMavenSession(),
                     getStagingDirectory( request.getParameters().getStagingDirectoryRoot(), profileId ),
-                    getArtifactRepositoryForNexus( stagingRepository ) );
+                    getDeploymentArtifactRepositoryForNexusStagingRepository( stagingRepository ) );
                 getLogger().info( " * Upload of locally staged artifacts finished." );
                 afterUpload( request.getParameters(), stagingRepository );
             }


### PR DESCRIPTION
Fixing this problem by using proper API call to create target
ArtifactRepository. Deployment repositories are not subject to
mirroring ever.
