### PR TITLE
Revert "maven plugins should be java 5 source compatible"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -349,8 +349,8 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.5</source>
-            <target>1.5</target>
+            <source>1.6</source>
+            <target>1.6</target>
           </configuration>
         </plugin>
         <!-- Manually run with: mvn clean com.mycila.maven-license-plugin:maven-license-plugin:1.9.0:format -->


### PR DESCRIPTION
This reverts commit 95dd0d8f2d3069f72e85bb1be8edcccd785d3ab0.

Undoing this change for now to have CI build it, and we should later see is Java5 really needed or not.
