### PR TITLE
PENDING: NXCM-5156: Staging plugin compatibility

### DIFF
--- a/staging/pom.xml
+++ b/staging/pom.xml
@@ -26,7 +26,7 @@
   <packaging>pom</packaging>
 
   <properties>
-    <staging.version>2.3.0-02</staging.version>
+    <staging.version>2.3.1-SNAPSHOT</staging.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Current compat matrix of nexus-staging-maven-plugins is:

1.0: works with nx 2.2 and 2.3, does not work with 2.4
1.1: works with nx 2.2 and 2.3, does not work with 2.4
1.2: works with nx 2.2 and 2.3, does not work with 2.4
1.3: works with nx 2.2 and 2.3, does not work with 2.4
1.4 (staged): busted, does not work with any version of nx
1.4.1 (staged): works with 2.4, does not work with 2.2 nor 2.3

So, I guess a "clean slate" version 1.5 could be introduced, that works with all 2.2+ nexuses.
