### PR TITLE
NXCM-5346: Simple fix applied

### DIFF
--- a/m2settings/maven-plugin/src/main/java/org/sonatype/nexus/maven/m2settings/PrompterImpl.java
+++ b/m2settings/maven-plugin/src/main/java/org/sonatype/nexus/maven/m2settings/PrompterImpl.java
@@ -42,6 +42,7 @@ public class PrompterImpl
     public PrompterImpl() throws IOException {
         this.console = new ConsoleReader();
         console.setHistoryEnabled(false);
+        console.setExpandEvents(false); // NXCM-5346: nexus-m2settings:download fails if password contains "!" character
     }
 
     public ConsoleReader getConsole() {


### PR DESCRIPTION
Not expanding events, those starting with `!`, `!#` etc.

Issue:
https://issues.sonatype.org/browse/NXCM-5346

CI:
https://bamboo.zion.sonatype.com/browse/NX-MVNF5-1
