### PR TITLE
NXCM-5424: Added p-u as direct dependency of the plugin

### DIFF
--- a/staging/maven-plugin/pom.xml
+++ b/staging/maven-plugin/pom.xml
@@ -40,14 +40,6 @@
       <artifactId>mojo-commons</artifactId>
     </dependency>
 
-    <!--
-      NXCM-5424: Needed by org.sonatype.plexus:plexus-sec-dispatcher:1.4 used by mojo-commons above 
-    -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
@@ -126,6 +118,14 @@
     <dependency>
       <groupId>org.sonatype.plexus</groupId>
       <artifactId>plexus-sec-dispatcher</artifactId>
+    </dependency>
+
+    <!--
+      NXCM-5424: Needed by org.sonatype.plexus:plexus-sec-dispatcher:1.4 (used by mojo-commons) 
+    -->
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
As SecDispatcher mojo commons uses to decrypt passwords
need it, and older versions of p-u lacks XmlStreamReader class.

This change will "pintpoint" p-u 3.0,8 (as defined in parent) as (explicit)
dependency of this plugin, and should fix NXCM-5424 where Maven "gave"
p-u 1.1 instead (as it was implicit dependency).

Issue
https://issues.sonatype.org/browse/NXCM-5424

CI
https://bamboo.zion.sonatype.com/browse/NX-MVNF8
