### PR TITLE
NEXUS-6735: Wait only if parallel build is used

### DIFF
--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/AbstractStagingMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/AbstractStagingMojo.java
@@ -330,9 +330,15 @@ public abstract class AbstractStagingMojo
     }
     if (result) {
       try {
-        // In case of parallel build, we need to ensure everything else is built
-        waitForOtherProjectsIfNeeded();
+        if (mavenSession.isParallel()) {
+          // In case of parallel build, we need to ensure everything else is built
+          waitForOtherProjectsIfNeeded();
+        }
+      } catch (NoSuchMethodError e) {
+        // ignore and continue, maven2 cannot do parallel anyway
+      }
 
+      try {
         if (getMavenSession().getResult().hasExceptions()) {
           if (detectBuildFailures) {
             // log failures found and bail out


### PR DESCRIPTION
Do not enter the loop to wait for other modules (needed in case of parallel build) when non-parallel build is underway. Hence, the endless loop that happens within wait will not happen. Also, this fixes the "extra 2sec" pause that entering the wait method introduces.

Issue
https://issues.sonatype.org/browse/NEXUS-6735

CI
http://bamboo.s/browse/NX-MVNF4
