### PR TITLE
Update DeployStagedMojo.java

### DIFF
--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/deploy/DeployStagedMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/deploy/DeployStagedMojo.java
@@ -46,7 +46,11 @@ public class DeployStagedMojo
           deployStrategy = getDeployStrategy(Strategies.DEFERRED);
         }
         else {
-          deployStrategy = getDeployStrategy(Strategies.STAGING);
+          if (isSkipStaging()){
+        	deployStrategy = getDeployStrategy(Strategies.DEFERRED);
+          } else {
+        	deployStrategy = getDeployStrategy(Strategies.STAGING);
+          }
         }
 
         final FinalizeDeployRequest request = new FinalizeDeployRequest(getMavenSession(), buildParameters());


### PR DESCRIPTION
While deploy mojo will take into consideration the skipStaging flag, deploy staged mojo does not yet.
We have an usecase where at some point in the delivery process we need to upload (deploy) the artifacts of an already deployed maven multi module project once again to another nexus repo. We use the already existent local directory structure from the first (deferred) deploy.
I have successfully tested this change on base of the 1.6.2 version of the nexus maven staging plugin.  
basti
