### PR TITLE
new feature - rc-open goal - start a new empty repository based on a specified staging profile id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
   </scm>
 
   <properties>
-    <nexus.version>2.9.1-02</nexus.version>
-    <maven.version>3.0.4</maven.version>
+    <nexus.version>2.11.1-01</nexus.version>
+    <maven.version>3.0.5</maven.version>
 
     <!-- Nexus integration-tests configuration -->
     <it.nexus.bundle.groupId>com.sonatype.nexus.assemblies</it.nexus.bundle.groupId>
@@ -396,7 +396,7 @@
           <plugin>
             <groupId>org.sonatype.plugins</groupId>
             <artifactId>sisu-maven-bridge-maven-plugin</artifactId>
-            <version>3.0</version>
+            <version>3.1.1</version>
             <executions>
               <execution>
                 <goals>

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -62,6 +62,7 @@ public class RcOpenStageRepositoryMojo
               );
 
         getLog().info(String.format(openedRepositoryMessageFormat, stagingRepositoryId));
+        // optional
         if (!openedRepositoryTargetFilename.isEmpty()){
             PrintWriter printWriter = null;
             try {

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -52,6 +52,6 @@ public class RcOpenStageRepositoryMojo
                 getStagingActionMessages().getMessageForAction(StagingAction.START),
                 null
               );
-        getLog().info(String.format(openedRepositoryMessageFormat, stagingProfileId));
+        getLog().info(String.format(openedRepositoryMessageFormat, stagingRepositoryId));
     }
 }

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -34,11 +34,18 @@ public class RcOpenStageRepositoryMojo
     @Parameter(property = "stagingProfileId", required = true)
     private String stagingProfileId;
 
+    /* This method creates a new repository who's ID would otherwise not be known.
+     *  It is important to allow end-users to output it's name in the format suitable to them.
+     *  We provide a sensible default here
+    **/
+    @Parameter(property = "openedRepositoryMessageFormat", required=false, defaultValue = "RC-Starting new staging repository with Profile ID: %s")
+    private String openedRepositoryMessageFormat;
+
     @Override
     public void doExecute(final StagingWorkflowV2Service stagingWorkflow)
             throws MojoExecutionException, MojoFailureException
     {
-        getLog().info("RC-Starting new staging repository with Profile ID: " + stagingProfileId);
+        getLog().info(String.format(openedRepositoryMessageFormat, stagingProfileId));
         final String stagingRepositoryId = stagingWorkflow.startStaging(
                 stagingWorkflow.selectProfile(stagingProfileId),
                 getStagingActionMessages().getMessageForAction(StagingAction.START),

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -1,0 +1,51 @@
+/*
+ * Sonatype Nexus (TM) Open Source Version
+ * Copyright (c) 2007-2015 Sonatype, Inc.
+ * All rights reserved. Includes the third-party code listed at http://links.sonatype.com/products/nexus/oss/attributions.
+ *
+ * This program and the accompanying materials are made available under the terms of the Eclipse Public License Version 1.0,
+ * which accompanies this distribution and is available at http://www.eclipse.org/legal/epl-v10.html.
+ *
+ * Sonatype Nexus (TM) Professional Version is available from Sonatype, Inc. "Sonatype" and "Sonatype Nexus" are trademarks
+ * of Sonatype, Inc. Apache Maven is a trademark of the Apache Software Foundation. M2eclipse is a trademark of the
+ * Eclipse Foundation. All other trademarks are the property of their respective owners.
+ */
+
+package org.sonatype.nexus.maven.staging.workflow.rc;
+
+import com.sonatype.nexus.staging.client.*;
+import org.apache.maven.plugins.annotations.Mojo;
+import java.util.*;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+
+import org.sonatype.nexus.maven.staging.workflow.AbstractStagingActionMojo;
+
+/**
+ * Opens a new Nexus staging repository.
+ *
+ * @author dashirov
+ * @since 1.6.7
+ */
+@Mojo(name = "rc-open", requiresProject = false, requiresDirectInvocation = true, requiresOnline = true)
+public class RcOpenStageRepositoryMojo
+        extends AbstractStagingActionMojo
+{
+    @Parameter(property = "stagingProfileId", required = true)
+    private String stagingProfileId;
+
+    @Parameter(property = "stagingDescription", required = true)
+    private String stagingDescription;
+
+    @Override
+    public void doExecute(final StagingWorkflowV2Service stagingWorkflow)
+            throws MojoExecutionException, MojoFailureException
+    {
+        getLog().info("RC-Starting new staging repository with Profile ID: " + stagingProfileId);
+        final String stagingRepositoryId = stagingWorkflow.startStaging(stagingWorkflow.selectProfile(stagingProfileId), stagingDescription, null );
+        getLog().info("Opened new staging repository with Id: " + stagingRepositoryId);
+    }
+}

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -13,15 +13,12 @@
 
 package org.sonatype.nexus.maven.staging.workflow.rc;
 
-import com.sonatype.nexus.staging.client.*;
-import org.apache.maven.plugins.annotations.Mojo;
-import java.util.*;
-import org.apache.maven.plugins.annotations.Parameter;
-
+import com.sonatype.nexus.staging.client.StagingWorkflowV2Service;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-
-
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.sonatype.nexus.maven.staging.StagingAction;
 import org.sonatype.nexus.maven.staging.workflow.AbstractStagingActionMojo;
 
 /**
@@ -37,15 +34,16 @@ public class RcOpenStageRepositoryMojo
     @Parameter(property = "stagingProfileId", required = true)
     private String stagingProfileId;
 
-    @Parameter(property = "stagingDescription", required = true)
-    private String stagingDescription;
-
     @Override
     public void doExecute(final StagingWorkflowV2Service stagingWorkflow)
             throws MojoExecutionException, MojoFailureException
     {
         getLog().info("RC-Starting new staging repository with Profile ID: " + stagingProfileId);
-        final String stagingRepositoryId = stagingWorkflow.startStaging(stagingWorkflow.selectProfile(stagingProfileId), stagingDescription, null );
+        final String stagingRepositoryId = stagingWorkflow.startStaging(
+                stagingWorkflow.selectProfile(stagingProfileId),
+                getStagingActionMessages().getMessageForAction(StagingAction.START),
+                null
+              );
         getLog().info("Opened new staging repository with Id: " + stagingRepositoryId);
     }
 }

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -21,11 +21,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.sonatype.nexus.maven.staging.StagingAction;
 import org.sonatype.nexus.maven.staging.workflow.AbstractStagingActionMojo;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
-
 /**
  * Opens a new Nexus staging repository.
  *
@@ -46,41 +41,16 @@ public class RcOpenStageRepositoryMojo
     @Parameter(property = "openedRepositoryMessageFormat", required=false, defaultValue = "Opened new staging repository with Id: %s")
     private String openedRepositoryMessageFormat;
 
-    @Parameter(property = "openedRepositoryTargetFilename", required = false)
-    private String openedRepositoryTargetFilename;
-
     @Override
     public void doExecute(final StagingWorkflowV2Service stagingWorkflow)
             throws MojoExecutionException, MojoFailureException
     {
         getLog().info("RC-Starting new staging repository with Profile ID: "+ stagingProfileId);
-
         final String stagingRepositoryId = stagingWorkflow.startStaging(
                 stagingWorkflow.selectProfile(stagingProfileId),
                 getStagingActionMessages().getMessageForAction(StagingAction.START),
                 null
               );
-
         getLog().info(String.format(openedRepositoryMessageFormat, stagingRepositoryId));
-        // optional
-        if (!openedRepositoryTargetFilename.isEmpty()){
-            PrintWriter printWriter = null;
-            try {
-                File file = new File(openedRepositoryTargetFilename);
-                FileWriter fileWriter = new FileWriter(file, false);
-                printWriter = new PrintWriter(fileWriter);
-                printWriter.println(stagingRepositoryId);
-            } catch (IOException e){
-                e.printStackTrace();
-            } finally {
-                if (printWriter != null){
-                    printWriter.close();
-                }
-            }
-        }
-
-
-
-
     }
 }

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -38,19 +38,20 @@ public class RcOpenStageRepositoryMojo
      *  It is important to allow end-users to output it's name in the format suitable to them.
      *  We provide a sensible default here
     **/
-    @Parameter(property = "openedRepositoryMessageFormat", required=false, defaultValue = "RC-Starting new staging repository with Profile ID: %s")
+    @Parameter(property = "openedRepositoryMessageFormat", required=false, defaultValue = "Opened new staging repository with Id: %s")
     private String openedRepositoryMessageFormat;
 
     @Override
     public void doExecute(final StagingWorkflowV2Service stagingWorkflow)
             throws MojoExecutionException, MojoFailureException
     {
-        getLog().info(String.format(openedRepositoryMessageFormat, stagingProfileId));
+        getLog().info("RC-Starting new staging repository with Profile ID: "+ stagingProfileId);
+
         final String stagingRepositoryId = stagingWorkflow.startStaging(
                 stagingWorkflow.selectProfile(stagingProfileId),
                 getStagingActionMessages().getMessageForAction(StagingAction.START),
                 null
               );
-        getLog().info("Opened new staging repository with Id: " + stagingRepositoryId);
+        getLog().info(String.format(openedRepositoryMessageFormat, stagingProfileId));
     }
 }

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/workflow/rc/RcOpenStageRepositoryMojo.java
@@ -21,6 +21,11 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.sonatype.nexus.maven.staging.StagingAction;
 import org.sonatype.nexus.maven.staging.workflow.AbstractStagingActionMojo;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
 /**
  * Opens a new Nexus staging repository.
  *
@@ -41,6 +46,9 @@ public class RcOpenStageRepositoryMojo
     @Parameter(property = "openedRepositoryMessageFormat", required=false, defaultValue = "Opened new staging repository with Id: %s")
     private String openedRepositoryMessageFormat;
 
+    @Parameter(property = "openedRepositoryTargetFilename", required = false)
+    private String openedRepositoryTargetFilename;
+
     @Override
     public void doExecute(final StagingWorkflowV2Service stagingWorkflow)
             throws MojoExecutionException, MojoFailureException
@@ -52,6 +60,26 @@ public class RcOpenStageRepositoryMojo
                 getStagingActionMessages().getMessageForAction(StagingAction.START),
                 null
               );
+
         getLog().info(String.format(openedRepositoryMessageFormat, stagingRepositoryId));
+        if (!openedRepositoryTargetFilename.isEmpty()){
+            PrintWriter printWriter = null;
+            try {
+                File file = new File(openedRepositoryTargetFilename);
+                FileWriter fileWriter = new FileWriter(file, false);
+                printWriter = new PrintWriter(fileWriter);
+                printWriter.println(stagingRepositoryId);
+            } catch (IOException e){
+                e.printStackTrace();
+            } finally {
+                if (printWriter != null){
+                    printWriter.close();
+                }
+            }
+        }
+
+
+
+
     }
 }


### PR DESCRIPTION
Hello,

For your consideration a new mojo - rc-open.
1. Intended to be part of the remote control family of mojos
2. Intended to serve as a first step in the "Teargeted Repository / advanced use case" part of the workflow document, replacing an HTTP REST API call.

Advantages:
1. Retrieves credentials from settings.xml, thus when used on CI systems similar to TeamCity provides security advantages to bare rest calls.
2. When invoked as a part of a project, similar to deploy mojos creates a more sensible, project / artifact / version aware description.
3. Tested with TeamCity to be service message emission capable when invoked with
-DopenedRepositoryMessageFormat="##teamcity[setParameter name='NEXUS_STAGING_REPOSITORY' value='%s']" CLI parameter, as long as key name is registered with TC build configuration.
4. Tested to function correctly without project
5. Tested to function correctly with a project
6. Tested in Targeted Repository / advanced use scenario. Tested using TeamCity CI with multiple build agents, single build chain:
      Step 1 [ Host 1 ] : use rc-open to start a new repository
      Step 2 [ Host 2 ] : use deploy to stage host/platform specific artifacts in the repository
      Step 2 [ Host 3 ] : use deploy to stage host/platform specific artifacts in the repository
      Step 3 [ Host 4 ] : use rc-close and rc-promote to complete staging

I suspect, testing can be also performed from multiple hosts / platforms after rc-close leading towards rc-promote or rc-drop nodes in the workflow