### PR TITLE
update lifecycle configuration

### DIFF
--- a/m2settings/maven-plugin/pom.xml
+++ b/m2settings/maven-plugin/pom.xml
@@ -35,6 +35,11 @@
     Provides support to download m2-settings templates from a remote Nexus Professional server.
   </description>
 
+  <properties>
+    <clm.skip>false</clm.skip>
+    <clm.applicationId>nexus-maven-plugins-m2settings</clm.applicationId>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,8 @@
 
     <!-- reporting section does not inherit report plugin versions, so we use a property to force the version -->
     <maven-plugin-plugin.version>3.2</maven-plugin-plugin.version>
+    <clm.skip>true</clm.skip>
+    <clm.applicationId>nexus-maven-plugins</clm.applicationId>
   </properties>
 
   <dependencyManagement>
@@ -312,6 +314,12 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>com.sonatype.clm</groupId>
+          <artifactId>clm-maven-plugin</artifactId>
+          <version>2.30.2-01</version>
+        </plugin>
+
         <plugin>
           <groupId>org.codehaus.plexus</groupId>
           <artifactId>plexus-component-metadata</artifactId>

--- a/staging/maven-plugin/pom.xml
+++ b/staging/maven-plugin/pom.xml
@@ -35,6 +35,11 @@
     Provides support to access staging functionality in a remote Nexus Professional server.
   </description>
 
+  <properties>
+    <clm.skip>false</clm.skip>
+    <clm.applicationId>nexus-maven-plugins-staging</clm.applicationId>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.sonatype.nexus.maven</groupId>


### PR DESCRIPTION
This changeset includes the necessary configuration of the clm-maven-plugin to integrate with our new internal Lifecycle deployment. Each delivered plugin connects to a separate, dedicated application. Credentials and Lifecycle server url is sourced via maven environment (per typical).

Sample execution:

> mvn clm:evaluate -pl :nexus-staging-maven-plugin

> mvn clm:evaluate -pl :nexus-m2settings-maven-plugin