### PR TITLE
revert guava upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>31.0.1-jre</version>
+        <version>14.0.1</version>
       </dependency>
 
       <dependency>

--- a/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/ProgressMonitorImpl.java
+++ b/staging/maven-plugin/src/main/java/org/sonatype/nexus/maven/staging/ProgressMonitorImpl.java
@@ -34,7 +34,7 @@ public class ProgressMonitorImpl
 
   public ProgressMonitorImpl() {
     this.logger = LoggerFactory.getLogger(getClass());
-    this.stopwatch = Stopwatch.createUnstarted();
+    this.stopwatch = new Stopwatch();
   }
 
   protected void maybePrintln() {


### PR DESCRIPTION
The most recent guava version is in direct conflict with NXRM 2 dependencies. Revert back to original, which is compatible with the guava version brought in transitively from NXRM 2.