### PR TITLE
build: restore compile scope for maven dependencies

### DIFF
--- a/m2settings/maven-plugin/pom.xml
+++ b/m2settings/maven-plugin/pom.xml
@@ -54,13 +54,11 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/staging/maven-plugin/pom.xml
+++ b/staging/maven-plugin/pom.xml
@@ -57,7 +57,6 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.sonatype.sisu</groupId>
@@ -68,26 +67,17 @@
 
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Following suggestion from https://github.com/sonatype/nexus-maven-plugins/pull/96#issuecomment-1045980911.