### PR TITLE
chore: update to 2.15 and bump xstream dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 
   <properties>
     <jackson.version>2.12.6</jackson.version>
-    <nexus.version>2.14.21-02</nexus.version>
+    <nexus.version>2.15.0-04</nexus.version>
     <maven.version>3.0.4</maven.version>
 
     <!-- Nexus integration-tests configuration -->
@@ -278,11 +278,10 @@
         </exclusions>
       </dependency>
 
-      <!-- Using latest to fix NEXUS-6836: Xstream on java8 -->
       <dependency>
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
-        <version>1.4.15</version>
+        <version>1.4.19</version>
       </dependency>
 
       <dependency>

--- a/staging/testsuite/src/test/java/org/sonatype/nexus/maven/staging/it/nxcm5412/Nxcm5412RcListProfilesIT.java
+++ b/staging/testsuite/src/test/java/org/sonatype/nexus/maven/staging/it/nxcm5412/Nxcm5412RcListProfilesIT.java
@@ -18,11 +18,11 @@ import java.util.Arrays;
 
 import org.sonatype.nexus.maven.staging.it.PreparedVerifier;
 import org.sonatype.nexus.maven.staging.it.SimpleRoundtripMatrixSupport;
-import org.sonatype.sisu.litmus.testsupport.hamcrest.FileMatchers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import org.junit.Test;
 import org.apache.maven.it.VerificationException;
+import org.sonatype.sisu.goodies.testsupport.hamcrest.FileMatchers;
 
 /**
  * IT for NXCM-5412 Add an rc-list goal to the nexus-staging-maven-plugin

--- a/staging/testsuite/src/test/java/org/sonatype/nexus/maven/staging/it/nxcm5412/Nxcm5412RcListRepositoriesIT.java
+++ b/staging/testsuite/src/test/java/org/sonatype/nexus/maven/staging/it/nxcm5412/Nxcm5412RcListRepositoriesIT.java
@@ -18,10 +18,10 @@ import java.util.Arrays;
 
 import org.sonatype.nexus.maven.staging.it.PreparedVerifier;
 import org.sonatype.nexus.maven.staging.it.SimpleRoundtripMatrixSupport;
-import org.sonatype.sisu.litmus.testsupport.hamcrest.FileMatchers;
 
 import org.apache.maven.it.VerificationException;
 import org.junit.Test;
+import org.sonatype.sisu.goodies.testsupport.hamcrest.FileMatchers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 


### PR DESCRIPTION
Upgrading xstream to 1.4.19 required an update to NXRM 2.15 before it could be completed successfully.